### PR TITLE
Fix the "Character in 'c' format wrapped in pack" warnings 

### DIFF
--- a/modules/filter
+++ b/modules/filter
@@ -55,7 +55,7 @@ sub parse_uri {
 sub decode_uri {
   my ($v) = @_;
   $v =~ s/\+/ /g;
-  $v =~ s/%(..)/pack("c",hex($1))/ge;
+  $v =~ s/%(..)/pack("C",hex($1))/ge;
   return $v;
 }
 


### PR DESCRIPTION
Fix the "Character in 'c' format wrapped in pack" warnings in perl 5.16 for URI-encoded high ASCII code characters, ex. "%DB"